### PR TITLE
add support for gpus

### DIFF
--- a/internal/coster/coster.go
+++ b/internal/coster/coster.go
@@ -44,6 +44,9 @@ var (
 	ResourceCostCPU = ResourceCostKind("cpu")
 	// ResourceCostMemory is a cost metric derived from memory utilization.
 	ResourceCostMemory = ResourceCostKind("memory")
+	// ResourceCostGPU is a cost metric derived from GPU utilization. At the present
+	// time kostanza assumes all GPU's in your cluster are homogenous.
+	ResourceCostGPU = ResourceCostKind("gpu")
 	// ResourceCostWeighted is a cost metric derived from a weighted average of memory and cpu utilization.
 	ResourceCostWeighted = ResourceCostKind("weighted")
 	// ResourceCostNode represents the overall cost of a node.
@@ -115,7 +118,7 @@ func NewKubernetesCoster(
 		prometheusExporter: prometheusExporter,
 		costExporters:      costExporters,
 		listenAddr:         listenAddr,
-		strategies:         []PricingStrategy{CPUPricingStrategy, MemoryPricingStrategy, WeightedPricingStrategy, NodePricingStrategy},
+		strategies:         []PricingStrategy{GPUPricingStrategy, CPUPricingStrategy, MemoryPricingStrategy, WeightedPricingStrategy, NodePricingStrategy},
 		podFilters:         PodFilters{RunningPodFilter},
 	}, nil
 }

--- a/internal/coster/table.go
+++ b/internal/coster/table.go
@@ -44,6 +44,7 @@ type CostTableEntry struct {
 	Labels                         Labels
 	HourlyMemoryByteCostMicroCents float64
 	HourlyMilliCPUCostMicroCents   float64
+	HourlyGPUCostMicroCents        float64
 }
 
 // Match returns true if all of the CostTableEntry's labels match some subeset
@@ -84,6 +85,13 @@ func (e *CostTableEntry) CPUCostMicroCents(millicpu float64, duration time.Durat
 func (e *CostTableEntry) MemoryCostMicroCents(membytes float64, duration time.Duration) int64 {
 	durfrac := float64(duration) / float64(time.Hour)
 	return int64(membytes * durfrac * float64(e.HourlyMemoryByteCostMicroCents))
+}
+
+// GPUCostMicroCents returns the cost of the provided number of gpus over a
+// given duration in millionths of a cent.
+func (e *CostTableEntry) GPUCostMicroCents(gpus float64, duration time.Duration) int64 {
+	durfrac := float64(duration) / float64(time.Hour)
+	return int64(gpus * durfrac * float64(e.HourlyGPUCostMicroCents))
 }
 
 // CostTable is a collection of CostTableEntries, generally used to look up pricing


### PR DESCRIPTION
Kostanza considers GPUs in weighted and node pricing strategies. There
is an additional GPUPricingStrategy that only emits cost data for gpus.

There are a few minor drive by refactorings that add utility methods to an internal structure (allocatedCostResourceMap) to make calling code arguably more readable.